### PR TITLE
Update readme. Update EBS storage value. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ AWS_ACCESS_KEY_ID
 5. `terraform apply --var-file=custom_vars.tfvars`
    1. If you want to pass or change any other variable in `vars.tf` use `--var "KEY=VALUE"`. See [vars.tf](./vars.tf) for the `KEY`. This will overrwide the `KEY` in [custom_vars.tfvars](./custo_vars.tfvars) file.
 
+Server will start downloading CS:GO. It might take up to 30 minutes for you to be able to connect to the game server.
+
 ## How To SSH Into The Server?
 Terraform will create the `id_rsa` and `id_rsa.pub` ssh keys to be used to access the instance.
 
@@ -57,6 +59,7 @@ if you want to change the game type you can change them accordingly in [custom_v
 | token | Steam Token | - | yes |
 | region | AWS Region | `"eu-west-2"` | yes |
 | security_group_name | Security Group Name Prefix | `"main"` | yes |
+| ebs_disk_size | Size for attached AWS EBS disk | `"40"` | no |
 | instance_type | AWS Instance Type | `"m5.large"` | yes |
 | password | CSGO Server Password (RCON and Private) | - | no |
 | tags | CSGO Server Tags For Information | - | no |

--- a/custom_vars.tfvars
+++ b/custom_vars.tfvars
@@ -15,3 +15,6 @@ map_group = "mg_active, mg_reserves, mg_hostage, mg_de_dust2"
 
 default_map = "de_mirage"
 max_players = "10"
+
+# AWS EBS
+ebs_disk_size = 40 # disk size in GB

--- a/ec2.tf
+++ b/ec2.tf
@@ -30,7 +30,7 @@ resource aws_instance main {
   user_data = data.template_file.main.rendered
 
   root_block_device {
-    volume_size = 30
+    volume_size = var.ebs_disk_size
   }
 
   security_groups = [

--- a/user-data.tplt
+++ b/user-data.tplt
@@ -7,7 +7,7 @@ sudo -- sh -c 'dpkg --add-architecture i386; add-apt-repository multiverse; apt-
 echo steam steam/question select "I AGREE" | sudo debconf-set-selections
 echo steam steam/license note '' | sudo debconf-set-selections
 
-sudo apt install -y curl wget file tar bzip2 gzip unzip bsdmainutils \
+sudo apt install -y curl wget file tar gdb bzip2 gzip unzip bsdmainutils \
    python util-linux ca-certificates binutils bc jq tmux netcat \
    lib32gcc1 lib32stdc++6 steamcmd
 

--- a/vars.tf
+++ b/vars.tf
@@ -9,6 +9,9 @@ variable region {
 variable security_group_name {
   description = "AWS Security Group name"
 }
+variable ebs_disk_size {
+  description = "Disk size of server holding disk"
+}
 
 variable instance_type {
   description = "AWS Instance Type"


### PR DESCRIPTION
Update readme to clearly state game server won't be available for at least 30minutes. Increase the EBS storage to 40GB as CS:GO space requirements went up. Add terraform variable to change EBS space as necessary via custom_vars.tfvars.